### PR TITLE
Fix swag target environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,21 @@ MAIN_PKG := ./cmd/marketplace/main.go
 MIGRATIONS_DIR := ./migrations
 GOPATH ?= $(HOME)/go
 GOMODCACHE ?= $(GOPATH)/pkg/mod
+GOCACHE ?= $(HOME)/.cache/go-build
+GOBIN := $(GOPATH)/bin
 export GOPATH
 export GOMODCACHE
-export PATH := $(PATH):$(GOPATH)/bin
+export GOCACHE
+export GOBIN
+export PATH := $(PATH):$(GOBIN)
 
 
 DATABASE_URL ?= host=localhost port=5432 user=postgres password=postgres dbname=marketplace sslmode=disable
 
-SWAG := $(GOPATH)/bin/swag
+SWAG := $(GOBIN)/swag
 $(SWAG):
 	@echo "Installing swag..."
+	@mkdir -p $(dir $(SWAG))
 	go install github.com/swaggo/swag/cmd/swag@latest
 
 GOOSE := go run github.com/pressly/goose/v3/cmd/goose@latest


### PR DESCRIPTION
## Summary
- set `GOCACHE` and `GOBIN` defaults for Go tools
- install swag into the configured `GOBIN` and create its directory if needed

## Testing
- `make swag`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b4537067f88331a1c5e5f90db1db64